### PR TITLE
Fixed JointPositionIsValid

### DIFF
--- a/JointOrientationBasics-Unity/Assets/JointOrientationBasics/Scripts/DoubleExponentialFilter.cs
+++ b/JointOrientationBasics-Unity/Assets/JointOrientationBasics/Scripts/DoubleExponentialFilter.cs
@@ -316,7 +316,7 @@ namespace JointOrientationBasics
         private bool JointPositionIsValid(Joint joint)
         {
             // if joint is 0 it is not valid.
-            bool posIsValid = joint.Position.Equals(Vector3.zero);
+            bool posIsValid = !joint.Position.Equals(Vector3.zero);
             //bool orientationIsValid = joint.Rotation.Equals(Helpers.QuaternionZero);
             bool orientationIsValid = true;
 


### PR DESCRIPTION
If joint is 0 is is _not_ valid and should return false, but this returns true if the joint position is 0. Should be posIsValid = pos != zero
